### PR TITLE
tweak graph publishing

### DIFF
--- a/pkg/Library/Graph/Nodes/GraphAgentNode.js
+++ b/pkg/Library/Graph/Nodes/GraphAgentNode.js
@@ -11,6 +11,6 @@ export const GraphAgentNode = {
   },
   state: {
     graphAgent$graphs: [],
-    graphAgent$publishedGraphsUrl: 'https://xenon-js-default-rtdb.firebaseio.com',
+    graphAgent$publishedGraphsUrl: 'https://xenon-js-default-rtdb.firebaseio.com/0_3',
   }
 };

--- a/pkg/Library/Graph/Nodes/GraphListNode.js
+++ b/pkg/Library/Graph/Nodes/GraphListNode.js
@@ -49,7 +49,7 @@ export const GraphListNode = {
   },
   state: {
     graphAgent$graphs: [],
-    graphAgent$publishedGraphsUrl: 'https://xenon-js-default-rtdb.firebaseio.com',
+    graphAgent$publishedGraphsUrl: 'https://xenon-js-default-rtdb.firebaseio.com/0_3',
     graphList$showMode: 'private',
     graphToolbar$actions: [{
       name: 'Show Public',

--- a/pkg/Run/web/config.js
+++ b/pkg/Run/web/config.js
@@ -33,9 +33,7 @@ globalThis.config = {
     //Worker: true,
     //WorkerTransit: true
   },
-  firebaseGraphsURL: "https://xenon-js-default-rtdb.firebaseio.com/0_3/demos/0823/publicGraphs"
-  // for local developement:
-  // firebaseGraphsURL: "https://xenon-js-default-rtdb.firebaseio.com/publicGraphs"
+  firebaseGraphsURL: "https://xenon-js-default-rtdb.firebaseio.com/0_3/publicGraphs"
 };
 
 globalThis.html = (strings, ...values) => `${strings[0]}${values.map((v, i) => `${v}${strings[i + 1]}`).join('')}`.trim();


### PR DESCRIPTION
this is how the hierarchy of the published graphs looks:
```
0_3/publicGraphs
   |-> user1
   |    |-> graph1
   |    |-> graph2
   |-> user2
        |-> graph1
```

pros:
- don't need to include the user name in published graph name to avoid name collisions
- can publish the demo graphs in the same folder, with a `NeonFlan` user name
- `Run` can access both - demo graphs and either user's published graphs with no special handling...

PS: 
I think this structure is still very simple, but allows us a lot more flexibility and robustness.
For the UX part, I haven't thought it through yet, but we could distinguish in the graphs bar between "All graphs" (that everyone published), "my graphs" (that i published) and "local graphs" (one that i edited and didn't publish)...
and treat local graphs more like drafts... 

<img width="791" alt="Screenshot 2023-09-01 at 6 27 10 PM" src="https://github.com/NeonFlan/xenonjs/assets/25067830/8681e7a2-c659-46d2-92e4-29679999e0a8">

And most importantly, we need to either indicate that the loaded graph is `readonly`, or silently create a clone, if user starts editing it - more discussion needed here!