### PR TITLE
Run to support graph search by name only, and bump README Run version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ XenonJs is suitable for you.
 ## Getting started
 
 XenonJs features 2 applications:
-* [`Run`](https://xenon-js.web.app/0.5/Run/): an application that allows you to run any XenonJs experience (aka Graph) in a browser
-* [`Build`](https://xenon-js.web.app/0.5/Build/): an web-based IDE that lets you compose XenonJs experiences (aka Graphs)
+* [`Run`](#run-graphs): an application that allows you to run any XenonJs experience (aka Graph) in a browser
+* [`Build`](#build-graphs): an web-based IDE that lets you compose XenonJs experiences (aka Graphs)
 
 ### Run Graphs
 
 To get started, try using our demo XenonJs Graphs:  
-* [Knowledge Space](https://xenon-js.web.app/0.5/Run/?graph=KnowledgeSpace)
-* [Video effects](https://xenon-js.web.app/0.5/Run/?graph=VideoRain)
-* [Image completion](https://xenon-js.web.app/0.5/Run/?graph=ImageCompletion)
-* [Translation](https://xenon-js.web.app/0.5/Run/?graph=TranslateWithAudio)
-* [Weather forecast](https://xenon-js.web.app/0.5/Run/?graph=LocalWeather)
+* [Knowledge Space](https://xenon-js.web.app/0.6/Run/?graph=neonflan/KnowledgeSpace)
+* [Video effects](https://xenon-js.web.app/0.6/Run/?graph=neonflan/VideoRain)
+* [Image completion](https://xenon-js.web.app/0.6/Run/?graph=neonflan/ImageCompletion)
+* [Translation](https://xenon-js.web.app/0.6/Run/?graph=neonflan/TranslateWithAudio)
+* [Weather forecast](https://xenon-js.web.app/0.6/Run/?graph=neonflan/LocalWeather)
 
 More demo Graphs can be found on our website: [xenonjs.com](https://xenon-js.web.app/#demos)
 
@@ -34,7 +34,7 @@ More demo Graphs can be found on our website: [xenonjs.com](https://xenon-js.web
 ### Build Graphs
 
 You can also build your very own XenonJs Graphs from the collection of XenonJs Nodes:
-* Try out the [Build](https://xenon-js.web.app/0.5/Build) IDE  
+* Try out the [Build](https://xenon-js.web.app/0.6/Build) IDE  
 * Here is a guide on how to use it: [Build README](./pkg/Build/README.md)
 
 
@@ -42,10 +42,10 @@ You can also build your very own XenonJs Graphs from the collection of XenonJs N
 The Graphs you compose in `Build` are immediately accessible in the `Run` application.
 
 To run a specific graph, pass its name as URL parameter to the `Run` app:  
-> [xenon-js.web.app/0.5/Run/?graph=GRAPH-NAME](https://xenon-js.web.app/0.5/Run/?graph=GRAPH-NAME)
+> [xenon-js.web.app/0.6/Run/?graph=GRAPH-NAME](https://xenon-js.web.app/0.6/Run/?graph=GRAPH-NAME)
 
 By default the Graphs you construct in `Build` are persisted in your browser's local storage. You can access a locally stored Graph at:  
-> [xenon-js.web.app/0.5/Run/?graph=local$GRAPH-NAME](https://xenon-js.web.app/0.5/Run/?graph=local$GRAPH-NAME)
+> [xenon-js.web.app/0.6/Run/?graph=local$GRAPH-NAME](https://xenon-js.web.app/0.6/Run/?graph=local$GRAPH-NAME)
 
 ### Graphs Library
 
@@ -66,12 +66,12 @@ It is also easy to run `Build` and `Run` locally:
 
 Clone the repo:
 ```
-git clone https://github.com/NeonFlan/xenonjs.git -b 0.5
+git clone https://github.com/NeonFlan/xenonjs.git -b 0.6
 
 cd xenonjs
 ```
 
-*Note: `0.5` is our stable(-ish) version. We are constantly adding cool new features, and you are welcome to try ToT at your own risk :)*
+*Note: `0.6` is our stable(-ish) version. We are constantly adding cool new features, and you are welcome to try ToT at your own risk :)*
 
 At the very first time run:
 ```

--- a/pkg/Library/CoreDesigner/GraphService.js
+++ b/pkg/Library/CoreDesigner/GraphService.js
@@ -141,15 +141,30 @@ const restoreLocalGraph = async (id) => {
 const fetchFbGraph = async (id) => {
   const firebaseUrl = globalThis.config.firebaseGraphsURL;
   if (firebaseUrl) {
-    const url = `${firebaseURL}/${id}.json`;
+    const url = `${firebaseUrl}/${id}.json`;
     try {
       const res = await fetch(url);
       if (res.status === 200) {
         const text = (await res.text())?.replace(/%/g, '$');
         const graph = JSON.parse(text);
-        return (typeof graph === 'string') ? JSON.parse(graph) : graph;
+        if (graph) {
+          return (typeof graph === 'string') ? JSON.parse(graph) : graph;
+        }
       }
-    } catch(x) {
+    } catch(x) {}
+    return findFbGraph(firebaseUrl, id);
+  }
+};
+
+const findFbGraph = async (firebaseUrl, id) => {
+  const res = await fetch(`${firebaseUrl}.json`);
+  if (res.status === 200) {
+    const text = (await res.text())?.replace(/%/g, '$');
+    const graphs = JSON.parse(text);
+    for (const userGraphs of values(graphs)) {
+      if (userGraphs[id]) {
+        return JSON.parse(userGraphs[id]);
+      }
     }
   }
 };

--- a/pkg/Run/web/main.js
+++ b/pkg/Run/web/main.js
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import './config.js';
+import {SafeObject} from '../../Library/CoreReactor/safe-object.js';
 import {Params} from '../../Library/Xenon/Utils/params.js';
 import {graph as baseGraph} from '../../Graphs/Base.js';
 import * as Persist from '../../Library/CoreFramework/Persist.js';
 import '../../Library/Dom/common/dom.js';
 import * as Library from '../../Library/CoreFramework/Library.js'
+
+const {assign, values} = SafeObject;
 
 // it rolls down stairs, alone or in pairs! it's log!
 const log = logf('Main', 'indigo');
@@ -48,11 +51,44 @@ export const main = async (xenon, App, Composer) => {
   }
 };
 
+<<<<<<< HEAD
+=======
+const restoreLocalGraph = async (id) => {
+  return Persist.restoreValue(`$GraphList$graphAgent$graphs.${id}`);
+};
+
+const fetchFbGraph = async (id) => {
+  const url = `${globalThis.config.firebaseGraphsURL}/${id}.json`;
+  const res = await fetch(url);
+  if (res.status === 200) {
+    const text = (await res.text())?.replace(/%/g, '$');
+    const graph = JSON.parse(text);
+    if (graph) {
+      return (typeof graph === 'string') ? JSON.parse(graph) : graph;
+    }
+  }
+  return findFbGraph(id);
+};
+
+const findFbGraph = async (id) => {
+  const res = await fetch(`${globalThis.config.firebaseGraphsURL}.json`);
+  if (res.status === 200) {
+    const text = (await res.text())?.replace(/%/g, '$');
+    const graphs = JSON.parse(text);
+    for (const userGraphs of values(graphs)) {
+      if (userGraphs[id]) {
+        return JSON.parse(userGraphs[id]);
+      }
+    }
+  }
+};
+
+>>>>>>> 7787b2f (Run to support graph search by name only, and bump README Run version)
 const loadLibraries = async ({customLibraries}, userSettings) => {
   const libraries = customLibraries ?? {};
   try {
     if (userSettings?.customLibraries) {
-      Object.assign(libraries, userSettings?.customLibraries);
+      assign(libraries, userSettings?.customLibraries);
     }
   } catch(e) {
     log.warn(`Failed to parse libraries: ${libString} (error: ${e})`);

--- a/pkg/Run/web/main.js
+++ b/pkg/Run/web/main.js
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import './config.js';
-import {SafeObject} from '../../Library/CoreReactor/safe-object.js';
 import {Params} from '../../Library/Xenon/Utils/params.js';
 import {graph as baseGraph} from '../../Graphs/Base.js';
 import * as Persist from '../../Library/CoreFramework/Persist.js';
+import {loadGraph} from '../../Library/CoreDesigner/GraphService.js';
 import '../../Library/Dom/common/dom.js';
 import * as Library from '../../Library/CoreFramework/Library.js'
-
-const {assign, values} = SafeObject;
 
 // it rolls down stairs, alone or in pairs! it's log!
 const log = logf('Main', 'indigo');
@@ -20,7 +18,7 @@ logf.flags.Main = true;
 export const main = async (xenon, App, Composer) => {
   // from whence, graph?
   const graphId = Params.getParam('graph') || await Persist.restoreValue(`$GraphList$graphAgent$selectedId`);
-  const buildGraph = GraphService.loadGraph(graphId);
+  const buildGraph = await loadGraph(graphId);
   if (buildGraph) {
     document.title = buildGraph.meta.id;
     // TODO: support assigning icons for graphs (maybe auto-generate?)
@@ -51,44 +49,11 @@ export const main = async (xenon, App, Composer) => {
   }
 };
 
-<<<<<<< HEAD
-=======
-const restoreLocalGraph = async (id) => {
-  return Persist.restoreValue(`$GraphList$graphAgent$graphs.${id}`);
-};
-
-const fetchFbGraph = async (id) => {
-  const url = `${globalThis.config.firebaseGraphsURL}/${id}.json`;
-  const res = await fetch(url);
-  if (res.status === 200) {
-    const text = (await res.text())?.replace(/%/g, '$');
-    const graph = JSON.parse(text);
-    if (graph) {
-      return (typeof graph === 'string') ? JSON.parse(graph) : graph;
-    }
-  }
-  return findFbGraph(id);
-};
-
-const findFbGraph = async (id) => {
-  const res = await fetch(`${globalThis.config.firebaseGraphsURL}.json`);
-  if (res.status === 200) {
-    const text = (await res.text())?.replace(/%/g, '$');
-    const graphs = JSON.parse(text);
-    for (const userGraphs of values(graphs)) {
-      if (userGraphs[id]) {
-        return JSON.parse(userGraphs[id]);
-      }
-    }
-  }
-};
-
->>>>>>> 7787b2f (Run to support graph search by name only, and bump README Run version)
 const loadLibraries = async ({customLibraries}, userSettings) => {
   const libraries = customLibraries ?? {};
   try {
     if (userSettings?.customLibraries) {
-      assign(libraries, userSettings?.customLibraries);
+      Object.assign(libraries, userSettings?.customLibraries);
     }
   } catch(e) {
     log.warn(`Failed to parse libraries: ${libString} (error: ${e})`);


### PR DESCRIPTION
now that the published graphs are grouped by the owner's name, the 
`.../Run/?graph=GRAPH-NAME`
links stop working and need to be `Run/?graph=owner/GRAPH-NAME`.
so i added support to search for them, if it's not accessible by just the name, so that either works...