### PR TITLE
Show "snackbar" statuses for Graph events, and some fixes

### DIFF
--- a/pkg/Library/Graph/Atoms/GraphAgent.js
+++ b/pkg/Library/Graph/Atoms/GraphAgent.js
@@ -21,7 +21,7 @@ async update(inputs, state, {output, isDirty, service}) {
     const publicGraphs = await this.loadPublicGraphs(publishedGraphsUrl)
     output({publicGraphs});
   }
-  // TODO(maria): refactor `initGraphs` so that return values are explicit.
+  // TODO(maria): refactor `initGraphs` so that it takes explicit inputs and return values are explicit.
   const outputs = await this.initGraphs(inputs, state);
   if (outputs) {
     return outputs;

--- a/pkg/Library/Graph/Nodes/GraphListNode.js
+++ b/pkg/Library/Graph/Nodes/GraphListNode.js
@@ -30,7 +30,7 @@ export const GraphListNode = {
   graphAgent: {
     type: '$library/Graph/Atoms/GraphAgent',
     inputs: ['readonly', 'user', 'publishedGraphsUrl', 'graphs', 'publicGraphs', 'graph', 'selectedMeta'],
-    outputs: ['graphs', 'publicGraphs', 'graph', 'selectedMeta'],
+    outputs: ['graphs', 'publicGraphs', 'graph', 'selectedMeta', 'message'],
     bindings: {
       event: 'actionExecutor$event',
       readonly: 'graphList$readonly',

--- a/pkg/Library/Graphs/Build.js
+++ b/pkg/Library/Graphs/Build.js
@@ -133,6 +133,10 @@ export const graph = {
     "NodeTypeList": {
       "type": "$library/Graph/Nodes/NodeTypeListNode",
       "container": "NodeTypeListFlyOut$flyOut#Container"
+    },
+    "UxStatusBar": {
+      "type": "$library/UX/Nodes/UXSnackBarNode",
+      "container": "OuterWorkPanel$panel#Container"
     }
   },
   "state": {
@@ -257,6 +261,7 @@ export const graph = {
     "GraphName$echo$style": "text-align: left",
     // "GraphListOptionsSelect$field$label": "Choose Avatar Generator",
     // "GraphListOptionsSelect$field$options": ["SuperBots", "SuperPets","Elders"],
+    "UxStatusBar$UXSnackBar$icon": "info",
     "Main$designer$layout": {
       "RightMainCollapse": {
         "order": "2"
@@ -357,6 +362,9 @@ export const graph = {
     "ObjectInspector$inspector$data": "NodeInspectorAdaptor$adaptor$data",
     "OpenStyleInspector$inspector$data": "NodeInspectorAdaptor$adaptor$data",
     "InfoEcho$echo$html": "NodeInspectorAdaptor$adaptor$info",
-    "InspectorToolbar$UXToolbar$actions": "AtomToolbar$UXToolbar$actions"
+    "InspectorToolbar$UXToolbar$actions": "AtomToolbar$UXToolbar$actions",
+
+    "UxStatusBar$UXSnackBar$message": "GraphList$graphAgent$message",
+    "UxStatusBar$UXSnackBar$open": "GraphList$graphAgent$message"
   }
 };

--- a/pkg/Library/UX/Atoms/UXSnackBar.js
+++ b/pkg/Library/UX/Atoms/UXSnackBar.js
@@ -4,15 +4,16 @@ export const atom = (log, resolve) => ({
  * Copyright 2023 NeonFlan LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-update({open}, state, {isDirty, invalidate}) {
+update({open, duration}, state, {isDirty, invalidate}) {
   if (isDirty('open')) {
     state.open = open;
   }
-  if (state.open) {
+  duration ??= 3000;
+  if (state.open && duration >= 0) {
     timeout(() => {
       state.open = false;
       invalidate();
-    }, 3000);
+    }, duration ?? 3000);
   }
 },
 onDidHide(inputs, state) {

--- a/pkg/Library/UX/Nodes/UXSnackbarNode.js
+++ b/pkg/Library/UX/Nodes/UXSnackbarNode.js
@@ -6,6 +6,6 @@
 export const UXSnackBarNode = {
   UXSnackBar: {
     type: '$library/UX/Atoms/UXSnackBar',
-    inputs: ['open', 'icon', 'message']
+    inputs: ['open', 'icon', 'message', 'duration']
   }
 };

--- a/pkg/Library/UX/UXNodeTypes.js
+++ b/pkg/Library/UX/UXNodeTypes.js
@@ -31,6 +31,7 @@ export const UXNodeTypes = {
       UXSnackBar$open: 'Nonce',
       UXSnackBar$icon: 'String',
       UXSnackBar$message: 'String',
+      UXSnackBar$duration: 'Number'
     },
     type: `$library/UX/Nodes/UXSnackBarNode`
   },


### PR DESCRIPTION
Bug fixes:
- Toolbars "reload public graphs" wasn't working
- If selected public graph is being unpublished, it needs to be unselected
- If a public graph is selected, and same-name local graph is being deleted -> the graph should not be unselected